### PR TITLE
Enable memory-mapped k-d trees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sif-kdtree"
 description = "simple, immutable, flat k-d tree"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2018"
 rust-version = "1.55"
 authors = ["Adam Reichold <adam.reichold@t-online.de>"]
@@ -17,6 +17,7 @@ rayon = { version = "1.7", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
+memmap2 = "0.7"
 proptest = "1.1"
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/sif-kdtree/badge.svg)](https://docs.rs/sif-kdtree)
 [![github.com](https://github.com/adamreichold/sif-kdtree/actions/workflows/test.yaml/badge.svg)](https://github.com/adamreichold/sif-kdtree/actions/workflows/test.yaml)
 
-A simple library implementing an immutable, flat representation of a [k-d tree](https://en.wikipedia.org/wiki/K-d_tree) supporting arbitrary spatial queries and nearest neighbour search.
+A simple library implementing an immutable, flat representation of a [k-d tree](https://en.wikipedia.org/wiki/K-d_tree) supporting arbitrary spatial queries, nearest neighbour search and backing storage based on memory maps.
 
 ## License
 

--- a/src/look_up.rs
+++ b/src/look_up.rs
@@ -80,9 +80,10 @@ impl<const N: usize> Query<[f64; N]> for WithinDistance<N> {
     }
 }
 
-impl<O> KdTree<O>
+impl<O, S> KdTree<O, S>
 where
     O: Object,
+    S: AsRef<[O]>,
 {
     /// Find objects matching the given `query`
     ///
@@ -95,8 +96,10 @@ where
         Q: Query<O::Point>,
         V: FnMut(&'a O) -> ControlFlow<()>,
     {
-        if !self.objects.is_empty() {
-            look_up(&mut LookUpArgs { query, visitor }, &self.objects, 0);
+        let objects = self.objects.as_ref();
+
+        if !objects.is_empty() {
+            look_up(&mut LookUpArgs { query, visitor }, objects, 0);
         }
     }
 
@@ -116,8 +119,10 @@ where
         Q: Query<O::Point> + Sync,
         V: Fn(&'a O) + Sync,
     {
-        if !self.objects.is_empty() {
-            par_look_up(&LookUpArgs { query, visitor }, &self.objects, 0);
+        let objects = self.objects.as_ref();
+
+        if !objects.is_empty() {
+            par_look_up(&LookUpArgs { query, visitor }, objects, 0);
         }
     }
 }

--- a/src/nearest.rs
+++ b/src/nearest.rs
@@ -2,9 +2,10 @@ use std::mem::swap;
 
 use crate::{split, KdTree, Object, Point};
 
-impl<O> KdTree<O>
+impl<O, S> KdTree<O, S>
 where
     O: Object,
+    S: AsRef<[O]>,
 {
     /// Find the object nearest to the given `target`
     ///
@@ -18,8 +19,10 @@ where
             best_match: None,
         };
 
-        if !self.objects.is_empty() {
-            nearest(&mut args, &self.objects, 0);
+        let objects = self.objects.as_ref();
+
+        if !objects.is_empty() {
+            nearest(&mut args, objects, 0);
         }
 
         args.best_match

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,30 +1,39 @@
+use std::marker::PhantomData;
+
 #[cfg(feature = "rayon")]
 use rayon::join;
 
 use crate::{KdTree, Object, Point};
 
-impl<O> KdTree<O>
+impl<O, S> KdTree<O, S>
 where
     O: Object,
+    S: AsRef<[O]> + AsMut<[O]>,
 {
     /// Construct a new tree by sorting the given `objects`
-    pub fn new(mut objects: Box<[O]>) -> Self {
-        sort(&mut objects, 0);
+    pub fn new(mut objects: S) -> Self {
+        sort(objects.as_mut(), 0);
 
-        Self { objects }
+        Self {
+            objects,
+            _marker: PhantomData,
+        }
     }
 
     #[cfg(feature = "rayon")]
     /// Construct a new tree by sorting the given `objects`, in parallel
     ///
     /// Requires the `rayon` feature and dispatches tasks into the current [thread pool][rayon::ThreadPool].
-    pub fn par_new(mut objects: Box<[O]>) -> Self
+    pub fn par_new(mut objects: S) -> Self
     where
         O: Send,
     {
-        par_sort(&mut objects, 0);
+        par_sort(objects.as_mut(), 0);
 
-        Self { objects }
+        Self {
+            objects,
+            _marker: PhantomData,
+        }
     }
 }
 


### PR DESCRIPTION
This makes the `KdTree` type generic over its backing storage so that in addition to boxed slices, other options like memory maps can be used.