### PR TITLE
Make coordinate types generic within reason

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sif-kdtree"
 description = "simple, immutable, flat k-d tree"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 rust-version = "1.55"
 authors = ["Adam Reichold <adam.reichold@t-online.de>"]
@@ -13,6 +13,7 @@ keywords = ["kdtree"]
 categories = ["data-structures", "simulation", "science::geo"]
 
 [dependencies]
+num-traits = "0.2"
 rayon = { version = "1.7", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/src/nearest.rs
+++ b/src/nearest.rs
@@ -1,10 +1,13 @@
 use std::mem::swap;
 
+use num_traits::Float;
+
 use crate::{split, KdTree, Object, Point};
 
 impl<O, S> KdTree<O, S>
 where
     O: Object,
+    <O::Point as Point>::Coord: Float,
     S: AsRef<[O]>,
 {
     /// Find the object nearest to the given `target`
@@ -15,7 +18,7 @@ where
     pub fn nearest(&self, target: &O::Point) -> Option<&O> {
         let mut args = NearestArgs {
             target,
-            distance_2: f64::INFINITY,
+            distance_2: <O::Point as Point>::Coord::infinity(),
             best_match: None,
         };
 
@@ -34,13 +37,14 @@ where
     O: Object,
 {
     target: &'b O::Point,
-    distance_2: f64,
+    distance_2: <O::Point as Point>::Coord,
     best_match: Option<&'a O>,
 }
 
 fn nearest<'a, O>(args: &mut NearestArgs<'a, '_, O>, mut objects: &'a [O], mut axis: usize)
 where
     O: Object,
+    <O::Point as Point>::Coord: Float,
 {
     loop {
         let (mut left, object, mut right) = split(objects);


### PR DESCRIPTION
This means restricting them to floating-point values where appropriate.